### PR TITLE
avoid to remove NDK. Might fix the missing org.jni_zero.JniInit class…

### DIFF
--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -40,7 +40,6 @@ jobs:
         df -h
         sudo rm -rf /usr/local/.ghcup
         sudo rm -rf /opt/hostedtoolcache/CodeQL
-        sudo rm -rf /usr/local/lib/android/sdk/ndk
         sudo rm -rf /usr/share/dotnet
         sudo rm -rf /opt/ghc
         sudo rm -rf /usr/local/share/boost


### PR DESCRIPTION
… during android talk build