### PR TITLE
chore: Use patch command instead of git apply

### DIFF
--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -50,7 +50,7 @@ jobs:
         pwd
         echo ${{ github.workspace }}
         ls -ahl ${{ github.workspace }}/repo/ios/patches/*.patch
-        git apply -v ${{ github.workspace }}/repo/ios/patches/*.patch
+        patch -p1 < ${{ github.workspace }}/repo/ios/patches/*.patch
 
         echo "Building..."
         cd tools_webrtc/ios


### PR DESCRIPTION
Before

```
# git apply -v ../../ios/patches/*.patch
Checking patch p2p/client/basic_port_allocator.cc...
error: while searching for:
    *flags |= webrtc::PORTALLOCATOR_DISABLE_TCP;
  }

  if (config_ && config) {
    // We need to regather srflx candidates if either of the following
    // conditions occurs:

error: patch failed: p2p/client/basic_port_allocator.cc:1361
error: p2p/client/basic_port_allocator.cc: patch does not apply
```

After

```
# patch -p1 < ../../ios/patches/*.patch           
patching file 'p2p/client/basic_port_allocator.cc'
patching file 'rtc_base/physical_socket_server.cc'
```